### PR TITLE
fixed toDateTime() and toJalali() methods

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,43 @@
+include: package:flutter_lints/flutter.yaml
+
+
+linter:
+
+  rules:
+    parameter_assignments : true
+    sort_unnamed_constructors_first : true
+    argument_type_not_assignable : true
+    prefer_single_quotes : true
+    avoid_void_async : true
+    unawaited_futures : true
+    await_only_futures : true
+  
+
+    
+    
+
+analyzer:
+
+  exclude:
+    - 'example/**'
+    - "**/*.g.dart"
+    - "**/*.freezed.dart"
+
+  errors:
+     missing_required_param: error
+     parameter_assignments: ignore
+     missing_return: error
+     sort_unnamed_constructors_first : ignore
+     avoid_function_literals_in_foreach_calls: ignore
+     avoid_print : ignore
+     argument_type_not_assignable : ignore
+     prefer_single_quotes : ignore
+     avoid_void_async : ignore
+     unawaited_futures : error
+     await_only_futures : error 
+     overridden_fields : ignore
+     avoid_bool_literals_in_conditional_expressions : ignore
+     prefer_final_locals : ignore 
+     
+     
+     

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/pdate_utils.dart
+++ b/lib/src/pdate_utils.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:persian_datetime_picker/src/date/shamsi_date.dart';
+import 'package:persian_datetime_picker/src/date/src/gregorian/gregorian_date.dart';
 
 import 'pdate_picker_common.dart';
 
@@ -263,10 +264,6 @@ extension JalaliExt on Jalali {
     return other.compareTo(this) == 0;
   }
 
-  DateTime toDateTime() {
-    return this.toDateTime();
-  }
-
   String _twoDigits(int n) {
     if (n >= 10) return "${n}";
     return "0${n}";
@@ -315,13 +312,13 @@ extension JalaliExt on Jalali {
   }
 
   String formatShortMonthDay() {
-    final f = this.formatter;
+    final f = formatter;
     return '${f.dd} ${f.mN}';
   }
 }
 
 extension DateTimeExt on DateTime {
   Jalali toJalali() {
-    return this.toJalali();
+    return Jalali.fromDateTime(this);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -55,11 +55,25 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -92,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
+  flutter_lints: ^1.0.3
 flutter:
 


### PR DESCRIPTION
Hi amir 
there are two methods in pdate_utils that are recursive and doesn't have any base case, so they would cause stack overflow.
i have deleted toDateTime() extension method on Jalali class since it is already implemented for this class and it isn't needed.
and changed the implementation of toJalali() method.

also since you have assigned values to parameters passed to function, dart static analyzer wouldn't let me compile the app.
so Ive added flutter_lints (default linter since flutter 2.0.0)  and override some rules to be able to build the app. however i highly recommend to change the implementation since assigning values to passed parameters is a bad practice and could cause unpredictable bugs.